### PR TITLE
Fix Windows GitHub Actions path for uv virtualenv

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,9 +24,14 @@ jobs:
     - name: Verify uv.lock is up-to-date
       run: uv lock --locked
     - name: Install dependencies
+      shell: bash
       run: |
         uv sync --all-extras --dev
-        echo "$PWD/.venv/bin" >> $GITHUB_PATH
+        if [ "$RUNNER_OS" == "Windows" ]; then
+          echo "$PWD/.venv/Scripts" >> $GITHUB_PATH
+        else
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
+        fi
     - name: Install Playwright system dependencies (Ubuntu)
       if: runner.os == 'Linux'
       run: |


### PR DESCRIPTION
Fixes the failing GitHub Actions tests on Windows. The error `The term 'playwright' is not recognized` was occurring because the Windows runner was trying to add `.venv/bin` to the path instead of `.venv/Scripts`, which is where Windows places executables. This updates the `test.yml` file to use conditional logic based on the runner OS to append the correct path.

Additionally, this will help resolve the current Dependabot PR failures for `astral-sh/setup-uv-7`. The missing labels `dependencies`, `actions`, and `python` have already been created in the repo, so no changes were needed to `dependabot.yml`.

---
*PR created automatically by Jules for task [14592974265331165996](https://jules.google.com/task/14592974265331165996) started by @Ciemaar*