### PR TITLE
⚡ Remove unnecessary blocking sleep in synchronization tasks

### DIFF
--- a/src/worker/celery_app.py
+++ b/src/worker/celery_app.py
@@ -1,7 +1,6 @@
 """Celery worker configuration and scheduled tasks for external data sync."""
 
 import logging
-import time
 from pathlib import Path
 from typing import Any, List
 
@@ -63,7 +62,6 @@ def sync_makerworld() -> List[dict[str, Any]]:
     and leverages the local Pydantic AI agent to extract model attributes.
     """
     logger.info("Starting MakerWorld synchronization via Ollama agent...")
-    time.sleep(2)
     result = run_scraper("makerworld", "https://makerworld.com/en/user/likes")
     logger.info(f"Sync complete. Found {len(result)} models.")
     return result
@@ -78,7 +76,6 @@ def sync_printables() -> List[dict[str, Any]]:
     and leverages the local Pydantic AI agent to extract model attributes.
     """
     logger.info("Starting Printables synchronization via Ollama agent...")
-    time.sleep(2)
     result = run_scraper("printables", "https://www.printables.com/user/collections")
     logger.info(f"Sync complete. Found {len(result)} models.")
     return result
@@ -94,7 +91,6 @@ def sync_thingiverse() -> List[dict[str, Any]]:
     Playwright and the local LLM agent to scrape the user's public collections page.
     """
     logger.info("Starting Thingiverse synchronization via Official API...")
-    time.sleep(2)
     # Prefer API logic for structured Thingiverse data.
     # If a token isn't provided, `fetch_thingiverse_collections` simply returns `[]`.
     result = fetch_thingiverse_collections()
@@ -114,7 +110,6 @@ def sync_cults3d() -> List[dict[str, Any]]:
     and leverages the local Pydantic AI agent to extract model attributes.
     """
     logger.info("Starting Cults3D synchronization via Ollama agent...")
-    time.sleep(2)
     result = run_scraper("cults3d", "https://cults3d.com/en/users/collections")
     logger.info(f"Sync complete. Found {len(result)} models.")
     return result
@@ -129,7 +124,6 @@ def sync_minihoarder() -> List[dict[str, Any]]:
     and leverages the local Pydantic AI agent to extract model attributes.
     """
     logger.info("Starting Minihoarder synchronization via Ollama agent...")
-    time.sleep(2)
     result = run_scraper("minihoarder", "https://www.minihoarder.com/library/")
     logger.info(f"Sync complete. Found {len(result)} models.")
     return result


### PR DESCRIPTION
💡 **What:** Removed redundant 2-second blocking `time.sleep()` calls from all platform synchronization tasks in `src/worker/celery_app.py`.

🎯 **Why:** These sleeps were unnecessarily blocking the Celery worker. Since the scraper already uses Playwright's `networkidle` to ensure the page is loaded before extraction begins, these manual delays provided no benefit and only increased task duration.

📊 **Measured Improvement:** Each of the 5 synchronization tasks now completes at least 2 seconds faster. In a full synchronization cycle across all platforms, this results in a cumulative saving of at least 10 seconds of worker time.

---
*PR created automatically by Jules for task [12152620241369395986](https://jules.google.com/task/12152620241369395986) started by @Ciemaar*