### PR TITLE
⚡ Optimize scraper and API sync to resolve N+1 query issue

### DIFF
--- a/src/worker/llm_scraper.py
+++ b/src/worker/llm_scraper.py
@@ -149,9 +149,20 @@ def run_scraper(source: str, url: str) -> List[dict[str, Any]]:
     db = SessionLocal()
     saved_items: List[dict[str, Any]] = []
     try:
+        # Batch query existing URLs to avoid N+1 queries
+        urls = [model.url for model in data if model.url]
+        existing_urls = set()
+
+        if urls:
+            existing_urls = {
+                url
+                for (url,) in db.query(PrintJob.source_url)
+                .filter(PrintJob.source_url.in_(urls))
+                .all()
+            }
+
         for model in data:
-            existing = db.query(PrintJob).filter(PrintJob.source_url == model.url).first()
-            if not existing:
+            if model.url and model.url not in existing_urls:
                 new_job = PrintJob(
                     title=model.title,
                     source=source,
@@ -162,10 +173,13 @@ def run_scraper(source: str, url: str) -> List[dict[str, Any]]:
                 )
                 db.add(new_job)
                 saved_items.append(model.model_dump())
+                # Add to set to avoid duplicates within the same batch
+                existing_urls.add(model.url)
         db.commit()
     except Exception as e:
         logger.error(f"Database error saving models: {e}")
         db.rollback()
+        saved_items.clear()
     finally:
         db.close()
 

--- a/src/worker/llm_scraper.py
+++ b/src/worker/llm_scraper.py
@@ -150,7 +150,7 @@ def run_scraper(source: str, url: str) -> List[dict[str, Any]]:
     saved_items: List[dict[str, Any]] = []
     try:
         # Batch query existing URLs to avoid N+1 queries
-        urls = [model.url for model in data if model.url]
+        urls = {model.url for model in data if model.url}
         existing_urls = set()
 
         if urls:
@@ -161,8 +161,11 @@ def run_scraper(source: str, url: str) -> List[dict[str, Any]]:
                 .all()
             }
 
+        new_urls = urls - existing_urls
+        seen_urls = set()
+
         for model in data:
-            if model.url and model.url not in existing_urls:
+            if model.url and model.url in new_urls and model.url not in seen_urls:
                 new_job = PrintJob(
                     title=model.title,
                     source=source,
@@ -174,7 +177,7 @@ def run_scraper(source: str, url: str) -> List[dict[str, Any]]:
                 db.add(new_job)
                 saved_items.append(model.model_dump())
                 # Add to set to avoid duplicates within the same batch
-                existing_urls.add(model.url)
+                seen_urls.add(model.url)
         db.commit()
     except Exception as e:
         logger.error(f"Database error saving models: {e}")

--- a/src/worker/thingiverse_api.py
+++ b/src/worker/thingiverse_api.py
@@ -87,6 +87,7 @@ def fetch_thingiverse_collections() -> List[dict[str, Any]]:
         except Exception as e:
             logger.error(f"Database error saving Thingiverse models: {e}")
             db.rollback()
+            saved_items.clear()
         finally:
             db.close()
 

--- a/src/worker/thingiverse_api.py
+++ b/src/worker/thingiverse_api.py
@@ -42,10 +42,10 @@ def fetch_thingiverse_collections() -> List[dict[str, Any]]:
 
         try:
             # Batch query existing URLs to avoid N+1 queries
-            urls = [
+            urls = {
                 str(item.get("url", f"https://www.thingiverse.com/thing:{item.get('id')}"))
                 for item in data
-            ]
+            }
 
             existing_urls = set()
             if urls:
@@ -56,12 +56,15 @@ def fetch_thingiverse_collections() -> List[dict[str, Any]]:
                     .all()
                 }
 
+            new_urls = urls - existing_urls
+            seen_urls = set()
+
             for item in data:
                 model_url = str(
                     item.get("url", f"https://www.thingiverse.com/thing:{item.get('id')}")
                 )
 
-                if model_url not in existing_urls:
+                if model_url in new_urls and model_url not in seen_urls:
                     new_job = PrintJob(
                         title=str(item.get("name", "Unknown Thingiverse Model")),
                         source="thingiverse",
@@ -73,7 +76,7 @@ def fetch_thingiverse_collections() -> List[dict[str, Any]]:
                     db.add(new_job)
 
                     # Add to set to avoid duplicates within the same batch
-                    existing_urls.add(model_url)
+                    seen_urls.add(model_url)
 
                     extracted = ExtractedModelInfo(
                         title=str(new_job.title),

--- a/src/worker/thingiverse_api.py
+++ b/src/worker/thingiverse_api.py
@@ -41,13 +41,27 @@ def fetch_thingiverse_collections() -> List[dict[str, Any]]:
         db = SessionLocal()
 
         try:
+            # Batch query existing URLs to avoid N+1 queries
+            urls = [
+                str(item.get("url", f"https://www.thingiverse.com/thing:{item.get('id')}"))
+                for item in data
+            ]
+
+            existing_urls = set()
+            if urls:
+                existing_urls = {
+                    url
+                    for (url,) in db.query(PrintJob.source_url)
+                    .filter(PrintJob.source_url.in_(urls))
+                    .all()
+                }
+
             for item in data:
                 model_url = str(
                     item.get("url", f"https://www.thingiverse.com/thing:{item.get('id')}")
                 )
 
-                existing = db.query(PrintJob).filter(PrintJob.source_url == model_url).first()
-                if not existing:
+                if model_url not in existing_urls:
                     new_job = PrintJob(
                         title=str(item.get("name", "Unknown Thingiverse Model")),
                         source="thingiverse",
@@ -57,6 +71,9 @@ def fetch_thingiverse_collections() -> List[dict[str, Any]]:
                         metadata_json={"extracted_via": "official_api", "raw_api_data": item},
                     )
                     db.add(new_job)
+
+                    # Add to set to avoid duplicates within the same batch
+                    existing_urls.add(model_url)
 
                     extracted = ExtractedModelInfo(
                         title=str(new_job.title),


### PR DESCRIPTION
This PR optimizes the Thingiverse API synchronization and general LLM scraper logic to resolve an N+1 database query issue.

**What:**
Individual database queries (`db.query(PrintJob).filter(...).first()`) executed per item inside the synchronization loop have been removed. They are replaced by a single, upfront batch query using the `IN` operator (`PrintJob.source_url.in_(...)`).

**Why:**
Querying the database sequentially within a loop causes significant performance degradation ("N+1 problem"). By batching the existence checks into a single query and maintaining a fast in-memory Python `set` for O(1) lookups during iteration, database roundtrips and connection overhead are minimized.

**Measured Improvement:**
Database queries for existence checks drop from O(N) (one per model in the batch) to O(1) (a single batch check). Duplicate items within the same batch are handled safely by appending the newly added URLs to the `existing_urls` set dynamically before the final commit.

---
*PR created automatically by Jules for task [5078719379236648596](https://jules.google.com/task/5078719379236648596) started by @Ciemaar*