### PR TITLE
🔒 [security] Remove hardcoded database credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: postgres:15
     environment:
       POSTGRES_USER: printqueue
-      POSTGRES_PASSWORD: password
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-password}
       POSTGRES_DB: printqueue
     ports:
       - "5432:5432"
@@ -37,7 +37,7 @@ services:
     ports:
       - "8000:8000"
     environment:
-      - DATABASE_URL=postgresql://printqueue:password@db:5432/printqueue
+      - DATABASE_URL=${DATABASE_URL:-postgresql://printqueue:${POSTGRES_PASSWORD:-password}@db:5432/printqueue}
       - REDIS_URL=redis://redis:6379/0
       - OLLAMA_HOST=http://ollama:11434
     depends_on:
@@ -53,7 +53,7 @@ services:
       - ./src:/app/src
       - ./watched_folder:/watched_folder
     environment:
-      - DATABASE_URL=postgresql://printqueue:password@db:5432/printqueue
+      - DATABASE_URL=${DATABASE_URL:-postgresql://printqueue:${POSTGRES_PASSWORD:-password}@db:5432/printqueue}
       - REDIS_URL=redis://redis:6379/0
       - OLLAMA_HOST=http://ollama:11434
       - WATCH_DIRECTORY=/watched_folder
@@ -69,7 +69,7 @@ services:
     volumes:
       - ./src:/app/src
     environment:
-      - DATABASE_URL=postgresql://printqueue:password@db:5432/printqueue
+      - DATABASE_URL=${DATABASE_URL:-postgresql://printqueue:${POSTGRES_PASSWORD:-password}@db:5432/printqueue}
       - REDIS_URL=redis://redis:6379/0
       - OLLAMA_HOST=http://ollama:11434
     depends_on:
@@ -85,7 +85,7 @@ services:
       - ./src:/app/src
       - ./watched_folder:/watched_folder
     environment:
-      - DATABASE_URL=postgresql://printqueue:password@db:5432/printqueue
+      - DATABASE_URL=${DATABASE_URL:-postgresql://printqueue:${POSTGRES_PASSWORD:-password}@db:5432/printqueue}
       - WATCH_DIRECTORY=/watched_folder
     depends_on:
       db:

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -6,7 +6,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     """Application settings, loaded from environment variables."""
 
-    database_url: str = "postgresql://printqueue:password@localhost:5432/printqueue"
+    database_url: str = "postgresql://localhost:5432/printqueue"
     redis_url: str = "redis://localhost:6379/0"
     ollama_host: str = "http://localhost:11434"
     watch_directory: str = "./watched_folder"


### PR DESCRIPTION
### What
Removes hardcoded database credentials from configuration files.

### Risk
High. Hardcoded passwords in plain text present a significant security vulnerability if code is leaked or the repository is compromised.

### Solution
* Updated `docker-compose.yml` to use environment variables (`${POSTGRES_PASSWORD:-password}`) for `POSTGRES_PASSWORD`.
* Updated `DATABASE_URL` in `docker-compose.yml` to use `DATABASE_URL=${DATABASE_URL:-postgresql://printqueue:${POSTGRES_PASSWORD:-password}@db:5432/printqueue}`.
* Updated `database_url` default in `src/app/config.py` to `postgresql://localhost:5432/printqueue` (omitting credentials).

---
*PR created automatically by Jules for task [6439231401903296471](https://jules.google.com/task/6439231401903296471) started by @Ciemaar*